### PR TITLE
build(deps): bump core-ktx to 1.19.0 and compileSdk to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ detekt {
 
 android {
     namespace = "com.msomu.androidkt"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.msomu.androidkt"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
 kotlin = "2.3.21"
-coreKtx = "1.17.0"
+coreKtx = "1.19.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"


### PR DESCRIPTION
## Summary

Upgrades `androidx.core:core-ktx` from **1.17.0 → 1.19.0** and bumps `compileSdk` from **36 → 37**.

This supersedes Dependabot PR #137, which bumped only `core-ktx` and failed CI. The 1.19.0 AAR declares `minCompileSdk=37` in its metadata, so compiling against API 36 fails with *"requires libraries and applications that depend on it to compile against version 37 or later."* Bumping `compileSdk` to 37 satisfies that requirement. (#137 was also based on a stale `main`, predating recent dependency merges.)

## Changes

- `gradle/libs.versions.toml`: `coreKtx` `1.17.0` → `1.19.0`
- `app/build.gradle.kts`: `compileSdk` `36` → `37`

## Compatibility notes

- The 1.19.0 AAR requires `minAndroidGradlePluginVersion=9.1.0`; the project is on AGP **9.2.1**, so this is satisfied.
- `targetSdk` is intentionally left at **36** — it's a runtime-behavior flag, not a compile requirement, and can be bumped separately after validating against API 37 behavior changes.
- `compileSdk = 37` requires the `android-37` SDK platform to be available in CI/local builds.

## Verification

The local build could not be run in the ephemeral session environment (no Android SDK installed), so validation relies on this PR's CI, which has the full toolchain.


---
_Generated by [Claude Code](https://claude.ai/code/session_012GfXZJpwFqUvCw84Cv6rZV)_